### PR TITLE
fix: await on command.execute

### DIFF
--- a/events/guild/message.js
+++ b/events/guild/message.js
@@ -40,7 +40,7 @@ module.exports = async (client, message) => {
     if (!command) return message.reply("Quelque chose n'a pas tourné rond, bizarre. Soit votre commande n'existe pas, soit elle est erronée <:hmmmm:898672241787674634>");
 
     try {
-        command.execute(client, message, args, profileData);
+        await command.execute(client, message, args, profileData);
     } catch (err) {
         console.log(err);
     }

--- a/events/guild/message.js
+++ b/events/guild/message.js
@@ -42,6 +42,7 @@ module.exports = async (client, message) => {
     try {
         await command.execute(client, message, args, profileData);
     } catch (err) {
-        console.log(err);
+        message.reply("Quelque chose n'a pas tourné rond, bizarre. Soit votre commande n'existe pas, soit elle est erronée <:hmmmm:898672241787674634>");
+        console.log('Catched error:', err);
     }
 }


### PR DESCRIPTION
Add `await` keyword on `command.execute()`

This will wait for `command.execute` to finish so the `try..catch` can handle errors if any 👍 

If there is no `await` on an async function that throws, the `try..catch` can't know this function has thrown since it is async